### PR TITLE
use express 5 and integrated middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,26 @@ A tiny Express wrapper for safe, rapid microservice development
 ## installation
 
 ```bash
-npm install express
-npm install body-parser
+npm install express@5
 npm install @apostrophecms/minuscule
 ```
 
 ## usage
 
 ```javascript
-const express = require('express');
-const { WebError, minuscule } = require('@apostrophecms/minuscule');
-const app = express();
-const bodyParser = require('body-parser');
-const yup = require('yup');
+import express from 'express';
+import yup from 'yup';
+import { WebError, minuscule } from '@apostrophecms/minuscule';
+
+const app = minuscule(express());
+
+// Allow traditional form submission format (if you want it)
+app.use(express.urlencoded({ extended: false }));
+
+// Allow JSON submissions (recommended)
+app.use(express.json());
+
+app.use(expectApiKey);
 
 // Example yup schema, see yup documentation
 const projectSchema = object({
@@ -26,60 +33,51 @@ const projectSchema = object({
   prod: boolean()
 });
 
-// Allow traditional form submission format (if you want it)
-app.use(bodyParser.urlencoded({ extended: false }));
-
-// Allow JSON submissions (recommended)
-app.use(bodyParser.json());
-
-const {
-  get,
-  post,
-  use
-} = minuscule(app);
-
-use(expectApiKey);
-
 // async GET API functions that just return a result
 
-get('/projects/:projectId', expectProjectId, async req => {
+get('/projects/:projectId', expectProjectId, async (req, res, next) => {
   const result = await myDatabase.findOne({
     id: req.params.projectId
   });
-  // returning an object -> automatic JSON response via req.res
-  return result;
+
+  return res.send(result);
 });
 
 // async POST API functions with easy, safe validation
 
-post('/projects', async req => {
+post('/projects', async (req, res, next) => {
   const project = await projectSchema.validate(req.body);
   await myDatabase.insertOne(project);
-  // returning an object -> automatic JSON response via req.res
-  return project;
+
+  return res.send(project);
 });
 
 // Global validation middleware as an async function
 
-async function expectApiKey(req) {
+async function expectApiKey(req, res, next) {
   const header = req.headers.authorization;
   if (!header) {
     throw new WebError(403, 'API key required');
   }
+
   const matches = header.match(/^ApiKey\s+(\S.*)$/i);
   if (matches[1] !== 'some-api-key') {
     throw new WebError(403, 'Invalid API key');
   }
+
+  next();
 }
 
 // Route-specific validation middleware as an async function
 
-async function expectProjectId(req) {
+async function expectProjectId(req, res, next) {
   if (!req.params.projectId.match(/^\w+/)) {
     throw new WebError(400, 'projectId must contain only letters, digits and underscores');
   }
   req.projectId = req.params.projectId;
   // Can also use "await." If no error is thrown execution continues
+
+  next();
 }
 
 app.listen(3000);
@@ -87,4 +85,14 @@ app.listen(3000);
 
 ## Other methods available
 
-`patch`, `put` and `del` are available and wrap `app.patch`, `app.post` and `app.delete` the same way that `get` and `post` wrap `app.get` and `app.post`. `del` was named to avoid conflict with the `delete` keyword when importing.
+The usual REST methods are available
+
+* delete
+* get
+* head
+* options
+* patch
+* post
+* put
+
+Please refer to [Express 5.x Routing methods](https://expressjs.com/en/5x/api.html#routing-methods) for the complete list.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-"use strict";
-
 class WebError extends Error {
   constructor(status, message) {
     super(`${status}: ${message}`);
@@ -8,116 +6,48 @@ class WebError extends Error {
   }
 }
 
-function minuscule(app) {
+function minuscule(express) {
+  const isProduction = process.env.ENV === 'production';
 
-  const prodLike = process.env.ENV === 'production';
+  const handleError = async (err, req, res, next) => {
+    // "ValidationError": Expected status code when using the yup library for validation
+    const status = err.status ||
+      (err.name === 'ValidationError' && 400) ||
+      500;
 
-  const self = {
+    console.error(
+      JSON.stringify(
+        {
+          url: req.url,
+          method: req.method,
+          ip: req.ip,
+          at: Date.now(),
+          status,
+          message: err.message,
+          stack: err.stack,
+        },
+        null,
+        isProduction ? '' : '  '
+      )
+    );
 
-    use(fn) {
-      app.use(async (req, res, next) => {
-        try {
-          await fn(req);
-          return next();
-        } catch (e) {
-          return self.handleError(req, e);
-        }
-      });
-    },
-
-    route(method, path, ...fns) {
-      if (((typeof method) !== 'string') || ((typeof path) !== 'string') || ((typeof fns[0]) !== 'function')) {
-        throw new Error(`route() must be called with (method, path, [...optionalMiddlewareFns], fn)`);
-      }
-      app[method](path, async req => {
-        let result;
-        for (const fn of fns) {
-          try {
-            result = await fn(req);
-          } catch (e) {
-            return self.handleError(req, e);
-          }
-        }
-        return req.res.send(result);
-      });
-    },
-
-    get(path, ...fns) {
-      if (((typeof path) !== 'string') || ((typeof fns[0]) !== 'function')) {
-        throw new Error(`get() must be called with (path, [...optionalMiddlewareFns], fn)`);
-      }
-      return self.route('get', path, ...fns);
-    },
-
-    post(path, ...fns) {
-      if (((typeof path) !== 'string') || ((typeof fns[0]) !== 'function')) {
-        throw new Error(`post() must be called with (path, [...optionalMiddlewareFns], fn)`);
-      }
-      return self.route('post', path, ...fns);
-    },
-
-    patch(path, ...fns) {
-      if (((typeof path) !== 'string') || ((typeof fns[0]) !== 'function')) {
-        throw new Error(`patch() must be called with (path, [...optionalMiddlewareFns], fn)`);
-      }
-      return self.route('patch', path, ...fns);
-    },
-
-    put(path, ...fns) {
-      if (((typeof path) !== 'string') || ((typeof fns[0]) !== 'function')) {
-        throw new Error(`put() must be called with (path, [...optionalMiddlewareFns], fn)`);
-      }
-      return self.route('put', path, ...fns);
-    },
-
-    del(path, ...fns) {
-      if (((typeof path) !== 'string') || ((typeof fns[0]) !== 'function')) {
-        throw new Error(`del() must be called with (path, [...optionalMiddlewareFns], fn)`);
-      }
-      return self.route('delete', path, ...fns);
-    },
-
-    handleError(req, e) {
-      if (e.name === 'ValidationError') {
-        // Expected status code when using the yup library for validation
-        e.status = 400;
-      }
-      if (!req.res) {
-        // Don't create a chicken and egg problem by calling self.error here
-        throw new Error('First argument to handleError must be req');
-      }
-      if (!e) {
-        throw new Error('Second argument to handleError must be error');
-      }
-      if (!prodLike) {
-        console.error(e.stack);
-      }
-      console.error(JSON.stringify({
-        url: req.url,
-        method: req.method,
-        ip: req.ip,
-        at: Date.now(),
-        status: e.status,
-        message: e.message,
-        ...prodLike ? { stack: e.stack } : {},
-      }, null, prodLike ? '' : '  '));
-      const res = req.res;
-      if (e.status) {
-        res.status(e.status);
-        return res.send(e.message);
-      } else {
-        res.status(500);
-        return res.send('error');
-      }
-    }
-
+    return res.status(status).send(status === 500 ? 'error' : err.message);
   };
 
-  return self;
+  const listen = (...args) => {
+    // Default error handler, must come last
+    express.use(handleError);
 
+    return express.listen(...args);
+  }
+
+  return {
+    ...express,
+    listen
+  };
 };
 
-module.exports = {
+export {
   WebError,
   minuscule
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A tiny Express wrapper for fast microservice development",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "mocha"
   },
@@ -23,9 +24,9 @@
   },
   "homepage": "https://github.com/apostrophecms/minuscule#readme",
   "devDependencies": {
-    "body-parser": "^1.20.3",
-    "express": "^4.21.0",
-    "mocha": "^10.7.3",
+    "body-parser": "^2.0.2",
+    "express": "^5.0.1",
+    "mocha": "^11.0.1",
     "yup": "^1.6.1"
   }
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Use express 5 and integrated middlewares

`minuscule` is now a wrapper for `express`.

When someone calls `app.listen`, it will register the default error handler (must be set after all existing middlewares and routes) before starting the HTTP server.

It also requires middlewares to use `res.send` instead of returning an object. (I'm almost certain I used this pattern in the past, but can't find any mention in the existing express 4.x nor 5.x documentation).

## What are the specific steps to test this change?

1. `npm test`

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [x] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
